### PR TITLE
ci: automate releases on semver tags

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    authors:
+      - dependabot
+    labels:
+      - CI
+      - dependencies
+  categories:
+    - title: "New Features :partying_face:"
+      labels:
+        - enhancement
+    - title: "Bugfixes :ant::hammer:"
+      labels:
+        - bug
+    - title: Everything Else
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     needs: ["lint", "build"]
     runs-on: ubuntu-latest
     env:
+      # Set CALCULATED_IMAGE_TAG to "latest" or "vX.Y.Z"
       CALCULATED_IMAGE_TAG: "${{ github.ref == 'refs/heads/main' && 'latest' || github.ref_name }}"
     permissions:
       packages: write
@@ -39,7 +40,7 @@ jobs:
           echo "Calculated image tag is $CALCULATED_TAG"
           echo "CALCULATED_IMAGE_TAG=$CALCULATED_TAG" >> "$GITHUB_ENV"
 
-      - name: Push Docker Image
+      - name: Upload Docker Image
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -47,3 +48,30 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ env.CALCULATED_IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  publish-github-release:
+    name: Publish GitHub Release w/ Changelog
+    needs: ["lint", "build"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    # Only run when a tag named vX.Y.Z is pushed
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          # LinkFix vX.Y.Z
+          name: LinkFix ${{ github.ref_name }}
+          body: |+
+            LinkFix was updated! You can find the latest Docker images on the [packages page](https://github.com/podaboutlist/linkfix-for-discord/pkgs/container/linkfix-for-discord).
+
+            Here's everything that's changed:
+          # TODO: Change this to `false` once we're happy with the generation
+          draft: true
+          # See .github/release for generation parameters
+          generate_release_notes: true


### PR DESCRIPTION
Use [`softprops/action-gh-release@v1`](https://github.com/marketplace/actions/gh-release) and [automated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) to publish a release whenever we push a new tag.

Closes #31 