### PR TITLE
fix: properly match Reddit URLs

### DIFF
--- a/src/replacements/RedditMediaReplacement.ts
+++ b/src/replacements/RedditMediaReplacement.ts
@@ -1,4 +1,27 @@
 export default class RedditMediaReplacement {
+  private previewToOriginal: (url: string) => string = (url) => {
+    let fixable = false;
+
+    [".jpeg", ".jpg", ".png", ".gif", ".webp"].forEach((ext: string) => {
+      fixable = fixable || url.includes(ext);
+    });
+
+    /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition --
+     *   This value is NOT "always truthy" eslint!!!
+     */
+    if (!fixable) {
+      return url;
+    }
+
+    // https://preview.redd.it/vsi8icu8mv8c1.jpeg?width=640&crop=smart&auto=webp&s=6a490e817519de3bc03f8131c3ae9943d90dc598
+    let newUrl = url.replace("//preview.", "//i.");
+    newUrl = newUrl.substring(0, newUrl.indexOf("?"));
+
+    console.debug(`[${this.constructor.name}]\tpreviewToOriginal()\t${url}\t${newUrl}`);
+
+    return newUrl;
+  };
+
   /**
    * Pull the *real* URLs out of our list of matched URLs
    * @param urls Array of matched URLs
@@ -23,7 +46,7 @@ export default class RedditMediaReplacement {
           console.debug(`[${this.constructor.name}]\treplaceURLs()\t${url}\t${decoded}`);
         }
 
-        decodedURIs.push(decoded);
+        decodedURIs.push(this.previewToOriginal(decoded));
       });
     });
 

--- a/src/replacements/RedditMediaReplacement.ts
+++ b/src/replacements/RedditMediaReplacement.ts
@@ -36,7 +36,7 @@ export default class RedditMediaReplacement {
    * @returns Message containing all fixed URLs separated by newlines
    */
   public replaceURLs: (messageContent: string) => string | null = (messageContent) => {
-    const urls = messageContent.match(/(\/\/|\.)reddit\.com\/media[^\s]+/g);
+    const urls = messageContent.match(/https?:\/\/(\w+\.)?reddit\.com\/media[^\s]+/g);
 
     if (urls === null) {
       return null;

--- a/src/replacements/RedditReplacement.ts
+++ b/src/replacements/RedditReplacement.ts
@@ -4,8 +4,8 @@ export default class RedditReplacement extends BaseReplacement {
   constructor(newDomain: string) {
     super(
       newDomain,
-      /https?:\/\/((((www|old|new|np)\.)?reddit\.com)|(redd\.it))\/(?!media)[^\s]+/g,
-      /((((www|old|new|np)\.)?reddit\.com)|(redd\.it))\//,
+      /https?:\/\/(redd.it|(\w+\.)?reddit.com\/(r|u|user)\/\w+\/(s|comments))\/[^\s]+/g,
+      /(((\w+\.)?reddit\.com)|(redd\.it))\//,
     );
   }
 }

--- a/src/replacements/index.ts
+++ b/src/replacements/index.ts
@@ -44,13 +44,19 @@ export const replacements: {
   "\\/\\/(\\w+\\.)?tiktok.com\\/((t\\/)?\\w+|@[^\\s]+\\/video)": (messageContent) => {
     return tiktokReplacer ? tiktokReplacer.replaceURLs(messageContent) : null;
   },
-  "(\\/\\/|\\.)reddit\\.com/(?!media)": (messageContent) => {
+  // reddit.com/(r|u|user)/(comments|s)/:id
+  // TODO: /s/:id links can be direct links to other sites like twitter.
+  "\\/\\/(\\w+\\.)?reddit\\.com\\/(r|u|user)\\/\\w+\\/(s|comments)\\/\\w+": (
+    messageContent,
+  ) => {
     return redditReplacer ? redditReplacer.replaceURLs(messageContent, "reddit.com/") : null;
   },
+  // don't match any subdomains like i.redd.it
   "\\/\\/redd\\.it/": (messageContent) => {
     return redditReplacer ? redditReplacer.replaceURLs(messageContent, "redd.it/") : null;
   },
-  "(\\/\\/|\\.)reddit\\.com/media": (messageContent) => {
+  // special case for reddit media proxy since we have to decode the URI
+  "\\/\\/(\\w+\\.)?reddit\\.com/media": (messageContent) => {
     return redditMediaReplacer ? redditMediaReplacer.replaceURLs(messageContent) : null;
   },
   // https://github.com/thelaao/phixiv#path-formats


### PR DESCRIPTION
- Only match reddit URLs with content (i.e. not links to users/subreddits/etc.)
- Convert `preview.redd.it` URLs to `i.redd.it` URLs when fixing `reddit.com/media?url=...` links
- closes #30