### PR TITLE
feat: link replacements for bluesky

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ alternatives that support rich media embeds.
 
 LinkFix currently supports:
   - Twitter/X (Tweet embeds via [fxtwitter](https://github.com/FixTweet/FixTweet))
+  - BlueSky/bsky via [vixbluesky](https://github.com/Rapougnac/VixBluesky)
   - TikTok (video embeds via [vxtiktok](https://github.com/dylanpdx/vxtiktok))
   - Instagram (image, video, and reel embeds via [ddinstagram](https://github.com/Wikidepia/InstaFix))
   - Reddit (text, image, and video embeds via [vxreddit](https://github.com/dylanpdx/vxReddit))

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,3 +18,4 @@ services:
       - TIKTOK_FIX_URL=vxtiktok.com
       - TWITTER_FIX_URL=fxtwitter.com
       - YOUTUBE_FIX_URL=youtu.be
+      - BSKY_FIX_URL=bskyx.app

--- a/src/replacements/BskyReplacement.ts
+++ b/src/replacements/BskyReplacement.ts
@@ -1,0 +1,15 @@
+import BaseReplacement from "./BaseReplacement";
+
+export default class BskyReplacement extends BaseReplacement {
+  constructor(newDomain: string) {
+    super(
+      newDomain,
+      // plc is 24 chars
+      // https://github.com/did-method-plc/did-method-plc?tab=readme-ov-file#identifier-syntax
+      // TID length is always 13 ASCII characters
+      // https://atproto.com/specs/record-key#record-key-type-tid
+      /https?:\/\/bsky\.app\/profile\/((\w|\.|-)+|(did:plc:[234567a-z]{24}))\/post\/[234567a-z]{13}(?!\/)/g,
+      /bsky\.app\//,
+    );
+  }
+}

--- a/src/replacements/index.ts
+++ b/src/replacements/index.ts
@@ -1,3 +1,4 @@
+import BskyReplacement from "./BskyReplacement";
 import InstagramReplacement from "./InstagramReplacement";
 import PixivReplacement from "./PixivReplacement";
 import RedditMediaReplacement from "./RedditMediaReplacement";
@@ -6,6 +7,9 @@ import TikTokReplacement from "./TikTokReplacement";
 import TwitterReplacement from "./TwitterReplacement";
 import YouTubeReplacement from "./YouTubeReplacement";
 
+const bskyReplacer = process.env.BSKY_FIX_URL
+  ? new BskyReplacement(process.env.BSKY_FIX_URL)
+  : undefined;
 const instagramReplacer = process.env.INSTAGRAM_FIX_URL
   ? new InstagramReplacement(process.env.INSTAGRAM_FIX_URL)
   : undefined;
@@ -64,4 +68,9 @@ export const replacements: {
     (messageContent) => {
       return pixivReplacer ? pixivReplacer.replaceURLs(messageContent) : null;
     },
+  // TID length is always 13 ASCII characters
+  // https://atproto.com/specs/record-key#record-key-type-tid
+  "\\/\\/bsky\\.app\\/profile\\/((\\w|\\.|-)+|(did:plc:[234567a-z]{24}))\\/post\\/[234567a-z]{13}(?!\\/)": (messageContent) => {
+    return bskyReplacer ? bskyReplacer.replaceURLs(messageContent) : null;
+  },
 };

--- a/src/replacements/index.ts
+++ b/src/replacements/index.ts
@@ -70,7 +70,8 @@ export const replacements: {
     },
   // TID length is always 13 ASCII characters
   // https://atproto.com/specs/record-key#record-key-type-tid
-  "\\/\\/bsky\\.app\\/profile\\/((\\w|\\.|-)+|(did:plc:[234567a-z]{24}))\\/post\\/[234567a-z]{13}(?!\\/)": (messageContent) => {
-    return bskyReplacer ? bskyReplacer.replaceURLs(messageContent) : null;
-  },
+  "\\/\\/bsky\\.app\\/profile\\/((\\w|\\.|-)+|(did:plc:[234567a-z]{24}))\\/post\\/[234567a-z]{13}(?!\\/)":
+    (messageContent) => {
+      return bskyReplacer ? bskyReplacer.replaceURLs(messageContent) : null;
+    },
 };


### PR DESCRIPTION
- supports normal URLS + `did:pic` urls (see [AT URI scheme](https://atproto.com/specs/at-uri-scheme))
- utilizes [VixBluesky](https://github.com/Rapougnac/VixBluesky)
- closes #142 