### PR TITLE
feat[dependabot]: gh actions, typescript, dotenv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,22 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    assignees:
+      - "ralphorama"
+    schedule:
+      interval: "weekly"
+      time: "18:00"
+      timezone: "America/New_York"
+    commit-message:
+      prefix: "github actions"
   - package-ecosystem: "npm"
     directory: "/"
     assignees:
       - "ralphorama"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       time: "18:00"
       timezone: "America/New_York"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,9 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      - dependency-name: "dotenv"
+      # hold back typescript for @typescript-eslint/typescript-estree
+      - dependency-name: "typescript"
+        versions: ">= 5.6.0"
       # Not sure why dependabot keeps trying to bump stuff by major versions
       # but it's ticking me off!!
       - dependency-name: "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tsconfig/node-lts": "^20.1.3",
         "@types/node": "^20.14.11",
         "discord.js": "^14.16.3",
-        "dotenv": "16.3.1",
+        "dotenv": "^16.4.5",
         "i18next": "^23.16.2",
         "i18next-fs-backend": "^2.3.2",
         "typescript": "<5.6.0",
@@ -1440,15 +1440,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/enabled": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tsconfig/node-lts": "^20.1.3",
     "@types/node": "^20.14.11",
     "discord.js": "^14.16.3",
-    "dotenv": "16.3.1",
+    "dotenv": "^16.4.5",
     "i18next": "^23.16.2",
     "i18next-fs-backend": "^2.3.2",
     "typescript": "<5.6.0",


### PR DESCRIPTION
- `@typescript-eslint/typescript-estree` doesn't support typescript >= 5.6.0, hold it back
- allow updating of dotenv
- enable dependabot for GitHub Actions